### PR TITLE
Remove accidental classname from static index

### DIFF
--- a/app/views/static/index.html.haml
+++ b/app/views/static/index.html.haml
@@ -2,7 +2,7 @@
 
 %ul.SummaryBoxes
   %li.SummaryBoxes--fresh
-    %a.quick(href="#TODO/new")
+    %a(href="#TODO/new")
       %h2 New
       %p
         %strong 54


### PR DESCRIPTION
This was accidentally added to a previous commit. I think it was part of debugging something. No reference to this in the rest of the repo.
